### PR TITLE
changes for symfony 4.0 compatibility #SymfonyConHackday2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
-      env: TARGET=cs_dry_run
     - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest"
     # test 2.7 LTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,51 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
 
-before_script:
-  - composer self-update
-  - composer install --dev
+env:
+  global:
+    - TARGET=test
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.0
+      env: TARGET=cs_dry_run
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    # test 2.7 LTS
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    # test 2.8 LTS
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*
+    # test the latest stable 3.x release
+    - php: 5.6
+      env: SYMFONY_VERSION=^3.0
+    # test the latest release (including beta releases)
+    - php: 7.1
+      env: DEPENDENCIES=beta
+  allow_failures:
+    - php: hhvm
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+
+install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+
 
 script:
   - phpunit --coverage-text

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="hautelook.router.template" class="Symfony\Bundle\FrameworkBundle\Routing\Router">
+        <service id="hautelook.router.template" public="true" class="Symfony\Bundle\FrameworkBundle\Routing\Router">
             <tag name="fsc_hateoas.url_generator" alias="templated" />
             <tag name="hateoas.url_generator" alias="templated_uri" />
             <tag name="monolog.logger" channel="router" />

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/framework-bundle": "~2.1|~3.0",
+        "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "hautelook/templated-uri-router": "~2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.5.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "hautelook/templated-uri-router": "~2.0"
     },


### PR DESCRIPTION
- update .travis.yml,
- bump minimum version for symfony/framework-bundle dependency to 2.7, to let composer run more efficiently with --prefer-lowest