### PR TITLE
Symfony 4 support and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - php: 5.4
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
         - php: 5.4
-          env: SYMFONY_VERSION='^2.1'
+          env: SYMFONY_VERSION='^2.8'
         - php: 7.0
           env: SYMFONY_VERSION='^3.0'
         - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,16 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.2
   - hhvm
 
 before_script:
   - composer self-update
-  - composer install --dev
+  - composer install
 
 script:
-  - phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-text
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,42 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.2
-  - hhvm
+sudo: false
+
+git:
+    depth: 1
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+    include:
+        - php: 5.3
+        - php: 5.4
+        - php: 5.5
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
+        - php: 7.2
+
+        - php: 5.3
+          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+
+        - php: 5.3
+          env: SYMFONY_VERSION='^2.1'
+        - php: 7.0
+          env: SYMFONY_VERSION='^3.0'
+        - php: 7.1
+          env: SYMFONY_VERSION='^4.0'
+    fast_finish: true
 
 before_script:
-  - composer self-update
-  - composer install
+    - if [[ $SYMFONY_VERSION  != '' ]]; then composer require "symfony/framework-bundle:$SYMFONY_VERSION" --no-update; fi
+    - composer self-update
+    - composer update $COMPOSER_FLAGS
 
 script:
-  - vendor/bin/phpunit --coverage-text
+    - vendor/bin/phpunit
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,15 @@ cache:
 
 matrix:
     include:
-        - php: 5.3
         - php: 5.4
         - php: 5.5
         - php: 5.6
         - php: 7.0
         - php: 7.1
         - php: 7.2
-
-        - php: 5.3
+        - php: 5.4
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
-
-        - php: 5.3
+        - php: 5.4
           env: SYMFONY_VERSION='^2.1'
         - php: 7.0
           env: SYMFONY_VERSION='^3.0'

--- a/DependencyInjection/CompilerPass/TemplatedRouterPass.php
+++ b/DependencyInjection/CompilerPass/TemplatedRouterPass.php
@@ -10,17 +10,17 @@ class TemplatedRouterPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $router = $container->findDefinition('router.default');
-        $argument = $router->getArgument(2);
+        $resourceOptions = $router->getArgument(2);
 
         $templatedRouter = $container->findDefinition('hautelook.router.template');
-        $templatedArgument = $templatedRouter->getArgument(2);
-        if (isset($argument['resource_type'])) {
-            $templatedArgument['resource_type'] = $argument['resource_type'];
+        $templatedResourceOptions = $templatedRouter->getArgument(2);
+        if (isset($resourceOptions['resource_type'])) {
+            $templatedResourceOptions['resource_type'] = $resourceOptions['resource_type'];
         }
-        if (isset($argument['strict_requirements'])) {
-            $templatedArgument['strict_requirements'] = $argument['strict_requirements'];
+        if (isset($resourceOptions['strict_requirements'])) {
+            $templatedResourceOptions['strict_requirements'] = $resourceOptions['strict_requirements'];
         }
-        $templatedRouter->replaceArgument(2, $templatedArgument);
+        $templatedRouter->replaceArgument(2, $templatedResourceOptions);
 
         $ref = new \ReflectionClass($templatedRouter->getClass());
         $cargs = $ref->getConstructor()->getParameters();

--- a/DependencyInjection/CompilerPass/TemplatedRouterPass.php
+++ b/DependencyInjection/CompilerPass/TemplatedRouterPass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Hautelook\TemplatedUriBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class TemplatedRouterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $router = $container->findDefinition('router.default');
+        $argument = $router->getArgument(2);
+
+        $templatedRouter = $container->findDefinition('hautelook.router.template');
+        $templatedArgument = $templatedRouter->getArgument(2);
+        if (isset($argument['resource_type'])) {
+            $templatedArgument['resource_type'] = $argument['resource_type'];
+        }
+        if (isset($argument['strict_requirements'])) {
+            $templatedArgument['strict_requirements'] = $argument['strict_requirements'];
+        }
+        $templatedRouter->replaceArgument(2, $templatedArgument);
+    }
+}
+

--- a/DependencyInjection/CompilerPass/TemplatedRouterPass.php
+++ b/DependencyInjection/CompilerPass/TemplatedRouterPass.php
@@ -21,6 +21,13 @@ class TemplatedRouterPass implements CompilerPassInterface
             $templatedArgument['strict_requirements'] = $argument['strict_requirements'];
         }
         $templatedRouter->replaceArgument(2, $templatedArgument);
+
+        $ref = new \ReflectionClass($templatedRouter->getClass());
+        $cargs = $ref->getConstructor()->getParameters();
+        if ($cargs[4]->getName() !== 'parameters') { // Symfony < 4
+            $args = $templatedRouter->getArguments();
+            unset($args[4]);
+            $templatedRouter->setArguments(array_values($args));
+        }
     }
 }
-

--- a/HautelookTemplatedUriBundle.php
+++ b/HautelookTemplatedUriBundle.php
@@ -2,8 +2,14 @@
 
 namespace Hautelook\TemplatedUriBundle;
 
+use Hautelook\TemplatedUriBundle\DependencyInjection\CompilerPass\TemplatedRouterPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class HautelookTemplatedUriBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new TemplatedRouterPass());
+    }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -28,6 +28,7 @@
                 <argument key="matcher_cache_class">%kernel.name%%kernel.environment%RFC6570UrlMatcher</argument>
             </argument>
             <argument type="service" id="router.request_context" on-invalid="ignore" />
+            <argument type="service" id="parameter_bag" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
     </services>

--- a/Tests/DependencyInjection/ContainerTest.php
+++ b/Tests/DependencyInjection/ContainerTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: goetas
+ * Date: 26.07.18
+ * Time: 13:11
+ */
+
+namespace Hautelook\TemplatedUriBundle\Tests\DependencyInjection;
+
+use Hautelook\TemplatedUriBundle\HautelookTemplatedUriBundle;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ContainerTest extends TestCase
+{
+    private function getContainer(array $configs = array())
+    {
+        $container = new ContainerBuilder();
+
+        $container->setParameter('kernel.name', 'app');
+        $container->setParameter('kernel.environment', 'test');
+        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/HautelookTemplatedUriBundle');
+        $container->setParameter('kernel.bundles', array('HautelookTemplatedUriBundle' => 'Hautelook\TemplatedUriBundle\HautelookTemplatedUriBundle'));
+        $container->setParameter('router.resource', array(
+            'resource_type' => 'foo'
+        ));
+
+
+        $bundle = new HautelookTemplatedUriBundle();
+
+        $extension = $bundle->getContainerExtension();
+        $extension->load($configs, $container);
+
+        return $container;
+    }
+
+    public function testConfig()
+    {
+        $container = $this->getContainer();
+        $container->compile();
+    }
+}

--- a/Tests/DependencyInjection/ContainerTest.php
+++ b/Tests/DependencyInjection/ContainerTest.php
@@ -11,6 +11,8 @@ namespace Hautelook\TemplatedUriBundle\Tests\DependencyInjection;
 use Hautelook\TemplatedUriBundle\HautelookTemplatedUriBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 class ContainerTest extends TestCase
 {
@@ -21,17 +23,27 @@ class ContainerTest extends TestCase
         $container->setParameter('kernel.name', 'app');
         $container->setParameter('kernel.environment', 'test');
         $container->setParameter('kernel.debug', true);
-        $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/HautelookTemplatedUriBundle');
+        $container->setParameter('kernel.cache_dir', tempnam(sys_get_temp_dir(), "HautelookTemplatedUriBundle"));
         $container->setParameter('kernel.bundles', array('HautelookTemplatedUriBundle' => 'Hautelook\TemplatedUriBundle\HautelookTemplatedUriBundle'));
         $container->setParameter('router.resource', array(
             'resource_type' => 'foo'
         ));
 
-
         $bundle = new HautelookTemplatedUriBundle();
+        $bundle->build($container);
+
+        $routerDef = new Definition('Symfony\Bundle\FrameworkBundle\Routing\Router');
+        $routerDef->setArguments(array(new Reference('service_container'), array(), array()));
+        $container->setDefinition('router.default', $routerDef);
+
+        $container->setDefinition('parameter_bag', new Definition('Symfony\Component\DependencyInjection\Container'));
+        $container->setDefinition('logger',  new Definition('Psr\Log\NullLogger'));
+        $container->setDefinition('router.request_context',  new Definition('Symfony\Component\Routing\RequestContext'));
 
         $extension = $bundle->getContainerExtension();
         $extension->load($configs, $container);
+
+        $container->getDefinition('hautelook.router.template')->setPublic(true);
 
         return $container;
     }
@@ -39,6 +51,6 @@ class ContainerTest extends TestCase
     public function testConfig()
     {
         $container = $this->getContainer();
-        $container->compile();
+        self::assertInstanceOf('Symfony\Bundle\FrameworkBundle\Routing\Router', $container->get('hautelook.router.template'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^5.4|^7.0",
-        "symfony/framework-bundle": "^2.1|^3.0|^4.0",
+        "symfony/framework-bundle": "^2.8|^3.0|^4.0",
         "hautelook/templated-uri-router": "^2.0@dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/framework-bundle": "~2.1|~3.0|^4.0",
-        "hautelook/templated-uri-router": "~2.0"
+        "hautelook/templated-uri-router": "~2.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0|^6.0|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": "^5.4|^7.0",
         "symfony/framework-bundle": "~2.1|~3.0|^4.0",
         "hautelook/templated-uri-router": "~2.0@dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0|^6.0|^7.0"
+        "phpunit/phpunit": "^4.8.36|^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-0": { "Hautelook\\TemplatedUriBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": "^5.4|^7.0",
-        "symfony/framework-bundle": "~2.1|~3.0|^4.0",
-        "hautelook/templated-uri-router": "~2.0@dev"
+        "symfony/framework-bundle": "^2.1|^3.0|^4.0",
+        "hautelook/templated-uri-router": "^2.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36|^5.0|^6.0|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,11 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/framework-bundle": "~2.1|~3.0",
+        "symfony/framework-bundle": "~2.1|~3.0|^4.0",
         "hautelook/templated-uri-router": "~2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-0": { "Hautelook\\TemplatedUriBundle": "" }


### PR DESCRIPTION
fixes https://github.com/hautelook/TemplatedUriBundle/issues/16
closes https://github.com/hautelook/TemplatedUriBundle/pull/20
closes https://github.com/hautelook/TemplatedUriBundle/pull/19
- added support for symfony 4
- added tests
- improved CI by testing multiple symfony framework versions and minimum dependencies
- drops support for php 5.3