### PR TITLE
[RFC] v 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^5.4|^7.0",
         "symfony/framework-bundle": "^2.8|^3.0|^4.0",
-        "hautelook/templated-uri-router": "^2.0"
+        "hautelook/templated-uri-router": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36|^5.0|^6.0|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "target-dir": "Hautelook/TemplatedUriBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }


### PR DESCRIPTION
https://github.com/hautelook/TemplatedUriRouter/pull/25 fixed a relatively important non-standard adherence of hautelook/TemplatedUriRouter to the RFC6570 specs. The fix was not backward compatible and will require a new major release (v3.0).

This requires also that this bundle updates the dependency requirements.

The questions/options are: 
1) Allow the TemplatedUriRouter v3  directly in TemplatedUriBundle 2.x  (and have people receiving a possibly braking update).
2) Release TemplatedUriBundle v3 and allow the TemplatedUriRouter v3 (safest)
3) Release TemplatedUriBundle v3 and allow the TemplatedUriRouter v3 and v2.x (safe and more BC compatible as requirements are less strict?)

Option 1 is the less likely to be the right one. Option 2 looks the best while option 3 looks a compromise for those who have explicitly in their compser.json a  TemplatedUriRouter v2 dependency.

@stof Any chance to have your opinion here?