### PR TITLE
Added Symfony 5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
     fast_finish: true
 
 before_script:
+    - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - if [[ $SYMFONY_VERSION  != '' ]]; then composer require "symfony/framework-bundle:$SYMFONY_VERSION" --no-update; fi
     - composer self-update
     - composer update $COMPOSER_FLAGS

--- a/DependencyInjection/CompilerPass/TemplatedRouterPass.php
+++ b/DependencyInjection/CompilerPass/TemplatedRouterPass.php
@@ -4,6 +4,7 @@ namespace Hautelook\TemplatedUriBundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
 
 class TemplatedRouterPass implements CompilerPassInterface
 {
@@ -20,6 +21,15 @@ class TemplatedRouterPass implements CompilerPassInterface
         if (isset($resourceOptions['strict_requirements'])) {
             $templatedResourceOptions['strict_requirements'] = $resourceOptions['strict_requirements'];
         }
+        
+        // Symfony 4 and 5 no longer uses those argument thus we add them conditionally for older Symfony versions
+        if (Kernel::MAJOR_VERSION < 5) {
+            $templatedResourceOptions['generator_base_class'] = '%hautelook.router.template.generator.class%';
+            $templatedResourceOptions['generator_cache_class'] = '%kernel.name%%kernel.environment%RF6570UrlGenerator';
+            $templatedResourceOptions['matcher_base_class'] = 'Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher';
+            $templatedResourceOptions['matcher_cache_class'] = '%kernel.name%%kernel.environment%RFC6570UrlMatcher';
+        }
+
         $templatedRouter->replaceArgument(2, $templatedResourceOptions);
 
         $ref = new \ReflectionClass($templatedRouter->getClass());

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,13 +19,9 @@
                 <argument key="cache_dir">%kernel.cache_dir%</argument>
                 <argument key="debug">%kernel.debug%</argument>
                 <argument key="generator_class">%hautelook.router.template.generator.class%</argument>
-                <argument key="generator_base_class">%hautelook.router.template.generator.class%</argument>
                 <argument key="generator_dumper_class">Symfony\Component\Routing\Generator\Dumper\PhpGeneratorDumper</argument>
-                <argument key="generator_cache_class">%kernel.name%%kernel.environment%RF6570UrlGenerator</argument>
                 <argument key="matcher_class">Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher</argument>
-                <argument key="matcher_base_class">Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher</argument>
                 <argument key="matcher_dumper_class">Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper</argument>
-                <argument key="matcher_cache_class">%kernel.name%%kernel.environment%RFC6570UrlMatcher</argument>
             </argument>
             <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="parameter_bag" on-invalid="ignore" />

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^5.4|^7.0",
         "symfony/framework-bundle": "^2.8|^3.0|^4.0|^5.0",
+        "symfony/http-kernel": "^2.8|^3.0|^4.0|^5.0",
         "hautelook/templated-uri-router": "^2.0|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Symfony 4 deprecated some Router options and now there have been removed from Symfony 5:
* generator_base_class
* generator_cache_class
* matcher_base_class
* matcher_cache_class

ref. https://symfony.com/blog/new-in-symfony-4-3-routing-improvements#deprecated-some-router-options

I've modified Templated Router definition to not include those options and add them via compiler pass. I'm not a fan of doing so but at least it works across all supported Symfony versions.