### PR TITLE
better symfony 5 router type detection

### DIFF
--- a/DependencyInjection/CompilerPass/TemplatedRouterPass.php
+++ b/DependencyInjection/CompilerPass/TemplatedRouterPass.php
@@ -21,9 +21,9 @@ class TemplatedRouterPass implements CompilerPassInterface
         if (isset($resourceOptions['strict_requirements'])) {
             $templatedResourceOptions['strict_requirements'] = $resourceOptions['strict_requirements'];
         }
-        
+
         // Symfony 4 and 5 no longer uses those argument thus we add them conditionally for older Symfony versions
-        if (Kernel::MAJOR_VERSION < 5) {
+        if (!class_exists('Symfony\Component\Routing\Generator\CompiledUrlGenerator')) {
             $templatedResourceOptions['generator_base_class'] = '%hautelook.router.template.generator.class%';
             $templatedResourceOptions['generator_cache_class'] = '%kernel.name%%kernel.environment%RF6570UrlGenerator';
             $templatedResourceOptions['matcher_base_class'] = 'Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher';

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php": "^5.4|^7.0",
         "symfony/framework-bundle": "^2.8|^3.0|^4.0|^5.0",
-        "symfony/http-kernel": "^2.8|^3.0|^4.0|^5.0",
         "hautelook/templated-uri-router": "^2.0|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Do not rely on HttpKernel to understand if we have a compiled router available

This addresses https://github.com/hautelook/TemplatedUriRouter/pull/29#discussion_r400806226
